### PR TITLE
Fix compiler warning from mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -17,7 +17,7 @@ defmodule UnitFun.Mixfile do
       elixir: "~> 1.1",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
-      deps: deps
+      deps: deps()
    ]
   end
 


### PR DESCRIPTION
The current version of Elixir (1.5.2) dislikes the function call without parentheses here (mix now generates `mix.exs` with them). This commit gets rid of that warning.